### PR TITLE
Add check on _sp property existence before accessing its properties

### DIFF
--- a/lib/ccznp.js
+++ b/lib/ccznp.js
@@ -70,17 +70,19 @@ function CcZnp () {
         self.emit('ready');
     });
 
-    this._innerListeners = {
-        spOpen: function () {
-            debug('The serialport ' + self._sp.path + ' is opened.');
-            self.emit('_ready');
-        },
-        spErr: function (err) {
-            self._sp.close();
-        },
-        spClose: function () {
-            debug('The serialport ' + self._sp.path + ' is closed.');
-            self._txQueue = null;
+	this._innerListeners = {
+		spOpen: function () {
+			if (self._sp) debug('The serialport ' + self._sp.path + ' is opened.');
+			else debug('Unknown serialport is opened');
+			self.emit('_ready');
+		},
+		spErr: function (err) {
+			self._sp.close();
+		},
+		spClose: function () {
+			if (self._sp) debug('The serialport ' + self._sp.path + ' is closed.');
+			else debug('Unknown serialport is closed');
+			self._txQueue = null;
             self._txQueue = [];
             self._sp = null;
             self._unpi = null;


### PR DESCRIPTION
This should prevent the following error (which should not occur in the first place):

```
TypeError: Cannot read property 'path' of null
    at SerialPortLight.spClose (/Users/robinbolscher/Development/homey-client/node_modules/cc-znp/lib/ccznp.js:82:47)
    at emitNone (events.js:105:13)
    at SerialPortLight.emit (events.js:207:7)
    at Socket._device.close (/Users/robinbolscher/Development/homey-client/node_modules/cc-znp/node_modules/serialport-light/index.js:112:18)
    at Socket.onack (/Users/robinbolscher/Development/homey-client/node_modules/linux-device/node_modules/socket.io-client/lib/socket.js:312:9)
    at Socket.onpacket (/Users/robinbolscher/Development/homey-client/node_modules/linux-device/node_modules/socket.io-client/lib/socket.js:236:12)
```