### PR TITLE
Robin/fix cc znp init

### DIFF
--- a/lib/ccznp.js
+++ b/lib/ccznp.js
@@ -70,17 +70,19 @@ function CcZnp () {
         self.emit('ready');
     });
 
-    this._innerListeners = {
-        spOpen: function () {
-            debug('The serialport ' + self._sp.path + ' is opened.');
-            self.emit('_ready');
-        },
-        spErr: function (err) {
-            self._sp.close();
-        },
-        spClose: function () {
-            debug('The serialport ' + self._sp.path + ' is closed.');
-            self._txQueue = null;
+	this._innerListeners = {
+		spOpen: function () {
+			if (self._sp) debug('The serialport ' + self._sp.path + ' is opened.');
+			else debug('Unknown serialport is opened');
+			self.emit('_ready');
+		},
+		spErr: function (err) {
+			self._sp.close();
+		},
+		spClose: function () {
+			if (self._sp) debug('The serialport ' + self._sp.path + ' is closed.');
+			else debug('Unknown serialport is closed');
+			self._txQueue = null;
             self._txQueue = [];
             self._sp = null;
             self._unpi = null;

--- a/lib/ccznp.js
+++ b/lib/ccznp.js
@@ -5,7 +5,7 @@ var util = require('util'),
     EventEmitter = require('events').EventEmitter;
 
 var Unpi = require('unpi'),
-    Serialport = require('serialport'),
+    Serialport = require('serialport-light'),
     debug = require('debug')('cc-znp'),
     logSreq = require('debug')('cc-znp:SREQ'),
     logSrsp = require('debug')('cc-znp:SRSP'),

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "debug": "^2.2.0",
     "enum": "^2.3.0",
-    "serialport": "^4.0.1",
+    "serialport-light": "git+ssh://git@github.com:athombv/node-serialport-light.git#production",
     "stream-browserify": "^2.0.1",
     "unpi": "^1.1.0"
   },


### PR DESCRIPTION
Zigbee-shepherd starts cc-znp twice when starting, once as primary
initialization, and then another time when performing a software reset.
This caused the serial port to open twice, the second time the serial
port was already open en will therefore be closed before opening it
again, this causes a ‘close’ event which breaks the cc-znp
initialization process.

NOTE: only `lib/ccznp.js` lines 142 - 148 are changed by this PR.